### PR TITLE
Fix issue featurette-image aspect ratio

### DIFF
--- a/site/assets/scss/main.scss
+++ b/site/assets/scss/main.scss
@@ -59,12 +59,6 @@ body { /* .dont-break-out { */
   letter-spacing: -.05rem;
 }
 
-.featurette-image {
-  width: 500px;
-  height: 500px;
-}
-
-
 /* RESPONSIVE CSS
 -------------------------------------------------- */
 

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -32,7 +32,7 @@
       {{ $page.Content }}
     </div>
     <div class="col-md-5 {{if (modBool $index 2)}}order-md-1{{end}}">
-      <img class="featurette-image img-fluid mx-auto" src="{{ $image_resized.Permalink }}" alt="Generic placeholder image">
+      <img class="img-fluid mx-auto" src="{{ $image_resized.Permalink }}" alt="Generic placeholder image">
     </div>
   </div>
 


### PR DESCRIPTION
Forceing the images into a 1:1 aspect ratio breaks images that where no
a perfect square.

Issue #3 