### PR TITLE
Fix NavBar expand/hide on mobile

### DIFF
--- a/site/assets/scss/main.scss
+++ b/site/assets/scss/main.scss
@@ -12,6 +12,9 @@ $info: $chelsi-orange;
 $body-bg: $chelsi-gray;
 $body-color: $chelsi-orange;
 
+$navbar-dark-brand-color: $chelsi-orange;
+$navbar-dark-brand-hover-color: rgba($chelsi-orange, .9);
+
 @import "../../../bootstrap/scss/variables";
 @import "../../../bootstrap/scss/mixins";
 @import "../../../bootstrap/scss/utilities";
@@ -25,7 +28,7 @@ $body-color: $chelsi-orange;
 // @import "../../../bootstrap/scss/tables";
 // @import "../../../bootstrap/scss/forms";
 @import "../../../bootstrap/scss/buttons";
-// @import "../../../bootstrap/scss/transitions";
+@import "../../../bootstrap/scss/transitions";
 @import "../../../bootstrap/scss/dropdown";
 // @import "../../../bootstrap/scss/button-group";
 @import "../../../bootstrap/scss/nav";
@@ -82,6 +85,15 @@ body { /* .dont-break-out { */
   -webkit-hyphens: auto;
   hyphens: auto;
 
+}
+
+header {
+  nav {
+    @extend .navbar;
+    @extend .navbar-dark;
+    @extend .bg-primary;
+    @extend .fixed-top;
+  }
 }
 
 

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -1,23 +1,19 @@
 <header>
-  <!-- Mobile Nav -->
-  <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-primary d-lg-none">
-    <a class="navbar-brand text-info" href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarCollapse">
-      <ul class="navbar-nav mr-auto">
-        {{ range $page := .Pages }}
-          <li class="nav-item">
-            <a class="nav-link" href="#{{ anchorize $page.Title }}">{{ $page.Title }}</a>
-          </li>
-        {{ end }}
-      </ul>
+  <nav>
+    <div class="container-fluid">
+      <a class="navbar-brand" href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
+      <button class="navbar-toggler d-lg-none" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse d-lg-none" id="navbarNav">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          {{ range $page := .Pages }}
+            <li class="nav-item">
+              <a class="nav-link" href="#{{ anchorize $page.Title }}">{{ $page.Title }}</a>
+            </li>
+          {{ end }}
+        </ul>
+      </div>
     </div>
-  </nav>
-
-  <!-- Desktop Nav -->
-  <nav class="navbar fixed-top navbar-expand-md navbar-dark fixed-top bg-primary d-none d-lg-block">
-    <a class="navbar-brand text-info" href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
   </nav>
 </header>


### PR DESCRIPTION
In the transition to Bootstrap v5 the burger NavBar menu broke. This
fixes it and moves more style into the css and out of the html.