### PR TITLE
Fix non circle images

### DIFF
--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -12,7 +12,7 @@
         "alt" $page.Params.image_alt
         "width" "140"
         "height" "140"
-        "method" "Fit"
+        "method" "Fill"
         "class" "rounded-circle"
         )
       }}


### PR DESCRIPTION
Some homepage images are not 1x1 so do not resize to circles well.