### PR TITLE
Fix carousel image aspect

### DIFF
--- a/site/assets/scss/main.scss
+++ b/site/assets/scss/main.scss
@@ -240,6 +240,15 @@ footer {
   }
 }
 
+.carousel-item img {
+  @extend .mx-auto;
+  width: 100%;
+  max-width: 1024px;
+
+  height: 100%;
+  max-height: 1024px;
+}
+
 .img-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);

--- a/site/content/portfolio/museum/index.md
+++ b/site/content/portfolio/museum/index.md
@@ -47,16 +47,16 @@ After interviewing the users I discovered that they really liked the gamificatio
    </div>
    <div class="carousel-inner">
       <div class="carousel-item active">
-         {{< img src="wireframes.02.png" class="d-block w-100" alt="..." width="2048" height="1024" />}}
+         {{< img src="wireframes.02.png" class="d-block" alt="..." width="2048" height="1024" />}}
    </div>
       <div class="carousel-item">
-         {{< img src="wireframes.03.png" class="d-block w-100" alt="..." width="2048" height="1024" />}}
+         {{< img src="wireframes.03.png" class="d-block" alt="..." width="2048" height="1024" />}}
    </div>
       <div class="carousel-item">
-         {{< img src="wireframes.04.png" class="d-block w-100" alt="..." width="2048" height="1024" />}}
+         {{< img src="wireframes.04.png" class="d-block" alt="..." width="2048" height="1024" />}}
    </div>
       <div class="carousel-item">
-         {{< img src="wireframes.06.png" class="d-block w-100" alt="..." width="2048" height="1024" />}}
+         {{< img src="wireframes.06.png" class="d-block" alt="..." width="2048" height="1024" />}}
    </div>
    </div>
    <button class="carousel-control-prev" type="button" data-bs-target="#gettingStartedCarouselIndicators" data-bs-slide="prev">


### PR DESCRIPTION
carousel images aspect was not respected so images became stretched.
This fixes this and limits the max size to better fit on larger screens.