### PR TITLE
Fix double col

### DIFF
--- a/site/layouts/shortcodes/row.html
+++ b/site/layouts/shortcodes/row.html
@@ -1,7 +1,7 @@
 {{- $classes := .Get 0 }}
 <div class="row{{ with $classes }} {{ . }}{{ end }}">
    {{- with .Inner }}
-      {{- if findRE "class=\"col(-[^\" ]*)(\"| )" . }}
+      {{- if findRE "class=\"col([^-\" ]*)(\"| )" . }}
          {{ . }}
       {{- else }}
    <div class="col">


### PR DESCRIPTION
The regex to auto add a col within a row incorrectly was adding cols
when not required. This lead to col within col and not rendering
correctly.