### PR TITLE
Fix scroll bar all rows

### DIFF
--- a/site/assets/scss/main.scss
+++ b/site/assets/scss/main.scss
@@ -88,7 +88,7 @@ a {
 }
 
 .row {
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 


### PR DESCRIPTION
Scroll default changed from scroll to auto. Ensures scroll bar only
appears where necessary, not on every line